### PR TITLE
Include stats for StepHeight and ClimbSpeed

### DIFF
--- a/source/Other/StatsPatches.cs
+++ b/source/Other/StatsPatches.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System.Reflection;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Datastructures;
@@ -90,11 +91,14 @@ public static class StatsPatches
                typeof(EntityBehaviorTemporalStabilityAffected).GetMethod("OnGameTick", AccessTools.all),
                prefix: new HarmonyMethod(AccessTools.Method(typeof(StatsPatches), nameof(ApplyStabilityStats)))
            );
-        
-        new Harmony(harmonyId).Patch(
-            typeof(EntityBehaviorPlayerPhysics).GetMethod("Initialize", AccessTools.all),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(StatsPatches), nameof(ApplyPlayerPhysicsPatches)))
-        );
+
+        if (api is ICoreClientAPI) // This is a client sided behavior
+        {
+            new Harmony(harmonyId).Patch(
+                typeof(EntityBehaviorPlayerPhysics).GetMethod("Initialize", AccessTools.all),
+                postfix: new HarmonyMethod(AccessTools.Method(typeof(StatsPatches), nameof(ApplyPlayerPhysicsPatches)))
+            );
+        }
     }
 
     public static void Unpatch(string harmonyId)

--- a/source/Other/StatsPatches.cs
+++ b/source/Other/StatsPatches.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System.Reflection;
 using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Datastructures;
 using Vintagestory.GameContent;
 
@@ -16,6 +17,8 @@ public static class StatsPatches
     public const string NutritionFactorStat = "nutritionFactor";
     public const string DamageFactorStat = "damageReceivedFactor";
     public const string MaxSaturationFactorStat = "maxSaturationFactor";
+    public const string StepHeightStat = "stepHeight";
+    public const string ClimbSpeedStat = "climbSpeed";
    
     public const string TemporalStabilityDropRateStat = "temporalStabilityDropRate";
     public const string TemporalStabilityOffsetStat = "temporalStabilityOffset";
@@ -87,7 +90,13 @@ public static class StatsPatches
                typeof(EntityBehaviorTemporalStabilityAffected).GetMethod("OnGameTick", AccessTools.all),
                prefix: new HarmonyMethod(AccessTools.Method(typeof(StatsPatches), nameof(ApplyStabilityStats)))
            );
+        
+        new Harmony(harmonyId).Patch(
+            typeof(EntityBehaviorPlayerPhysics).GetMethod("Initialize", AccessTools.all),
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(StatsPatches), nameof(ApplyPlayerPhysicsPatches)))
+        );
     }
+
     public static void Unpatch(string harmonyId)
     {
         new Harmony(harmonyId).Unpatch(typeof(EntityPlayer).GetMethod("GetWalkSpeedMultiplier", AccessTools.all), HarmonyPatchType.Postfix, harmonyId);
@@ -217,5 +226,11 @@ public static class StatsPatches
                 __instance.TempStabChangeVelocity += surfaceStabilityOffset * deltaTime;
             }
         }
+    }
+
+    private static void ApplyPlayerPhysicsPatches(EntityBehaviorPlayerPhysics __instance, EntityProperties properties, JsonObject attributes)
+    {
+        __instance.StepHeight *= __instance.Entity.Stats.GetBlended(StepHeightStat);
+        __instance.climbUpSpeed  *= __instance.Entity.Stats.GetBlended(ClimbSpeedStat);
     }
 }


### PR DESCRIPTION
This tiny PR uses the player's `EntityBehaviorPlayerPhysics` to add a modifier to step height and climb speed. A postfix harmony patch was used for consistency with other applications inside of `StatPatches`. However this should also be achievable by doing this in `ModSystems` instead:

```C#
    public override void StartClientSide(ICoreClientAPI api)
    {
        api.Event.PlayerEntitySpawn += ApplyPlayerPhysicsStats;
    }

    private void ApplyPlayerPhysicsStats(IClientPlayer byPlayer)
    {
        var physBehavior = byPlayer.Entity.GetBehavior<EntityBehaviorPlayerPhysics>();
        if (physBehavior == null) return;
        physBehavior.StepHeight *= byPlayer.Entity.Stats.GetBlended(StepHeightStat);
        physBehavior.climbUpSpeed  *= byPlayer.Entity.Stats.GetBlended(ClimbSpeedStat);
    }
```